### PR TITLE
another multibatch crash fix

### DIFF
--- a/engine/src/main/java/com/rockbite/bongo/engine/render/PolygonSpriteBatchMultiTextureMULTIBIND.java
+++ b/engine/src/main/java/com/rockbite/bongo/engine/render/PolygonSpriteBatchMultiTextureMULTIBIND.java
@@ -1196,7 +1196,7 @@ public class PolygonSpriteBatchMultiTextureMULTIBIND implements PolyBatchWithEnc
 
 		int triangle = 0;
 		int vertexOffset = this.vertexIndex;
-		for (int i = 0; i < spriteVertices.length; i+= 5) { //copy and fake
+		for (int i = 0; i < count; i+= 5) { //copy and fake
 
 			int rootOffset = triangle * VERTEX_SIZE;
 


### PR DESCRIPTION
this seems to crash because sometimes count is smaller then the array size. case is select box bitmap font stuff, and i had a project to reproduce it.